### PR TITLE
Add option to rotate images on load by 90, 180, or 270 degrees

### DIFF
--- a/src/picframe/config/configuration_example.yaml
+++ b/src/picframe/config/configuration_example.yaml
@@ -23,6 +23,7 @@ viewer:
   display_w: null                         # width of display surface (null->None will use max returned by hardware)
   display_h: null                         # height of display surface
   display_power: 2                        # default=0. choices={0, 1, 2}, 0 will use legacy `vcgencmd`, 1 will use `xset`, 2 will use 'wlr-randr' to blank the display
+  image_rotate: 0                         # default=0 (0, 90, 180, 720), amount in degrees to rotate image by
   use_glx: False                          # default=False. Set to True on linux with xserver running. NB use_sdl2 might need to be False for this to work.
   use_sdl2: True                          # default=True. pysdl2 can use display without xserver, it should be installed as a dependency of pi3d
                                           # but might need `sudo apt install libsdl2-dev` if picframe gives errors about missing sdl2

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -31,6 +31,7 @@ DEFAULT_CONFIG = {
         'display_w': None,
         'display_h': None,
         'display_power': 2,
+        'image_rotate': 0,
         'use_glx': False,                          # default=False. Set to True on linux with xserver running
         'use_sdl2': True,
         'test_key': 'test_value',

--- a/src/picframe/viewer_display.py
+++ b/src/picframe/viewer_display.py
@@ -74,6 +74,9 @@ class ViewerDisplay:
         self.__display_w = None if config['display_w'] is None else int(config['display_w'])
         self.__display_h = None if config['display_h'] is None else int(config['display_h'])
         self.__display_power = int(config['display_power'])
+        self.__image_rotate = int(config['image_rotate'])
+        if self.__image_rotate not in [0, 90, 180, 270]:
+            self.__image_rotate = 0
         self.__use_sdl2 = config['use_sdl2']
         self.__use_glx = config['use_glx']
         self.__alpha = 0.0  # alpha - proportion front image to back
@@ -241,23 +244,31 @@ class ViewerDisplay:
 
     def __orientate_image(self, im, pic):
         ext = os.path.splitext(pic.fname)[1].lower()
-        if ext in ('.heif', '.heic'):  # heif and heic images are converted to PIL.Image obects and are alway in correct orienation # noqa: E501
-            return im
-        orientation = pic.orientation
-        if orientation == 2:
-            im = im.transpose(Image.FLIP_LEFT_RIGHT)
-        elif orientation == 3:
-            im = im.transpose(Image.ROTATE_180)  # rotations are clockwise
-        elif orientation == 4:
-            im = im.transpose(Image.FLIP_TOP_BOTTOM)
-        elif orientation == 5:
-            im = im.transpose(Image.FLIP_LEFT_RIGHT).transpose(Image.ROTATE_90)
-        elif orientation == 6:
-            im = im.transpose(Image.ROTATE_270)
-        elif orientation == 7:
-            im = im.transpose(Image.FLIP_LEFT_RIGHT).transpose(Image.ROTATE_270)
-        elif orientation == 8:
+
+        if ext not in ('.heif', '.heic'):  # heif and heic images are converted to PIL.Image obects and are alway in correct orienation # noqa: E501
+            orientation = pic.orientation
+            if orientation == 2:
+                im = im.transpose(Image.FLIP_LEFT_RIGHT)
+            elif orientation == 3:
+                im = im.transpose(Image.ROTATE_180)  # rotations are clockwise
+            elif orientation == 4:
+                im = im.transpose(Image.FLIP_TOP_BOTTOM)
+            elif orientation == 5:
+                im = im.transpose(Image.FLIP_LEFT_RIGHT).transpose(Image.ROTATE_90)
+            elif orientation == 6:
+                im = im.transpose(Image.ROTATE_270)
+            elif orientation == 7:
+                im = im.transpose(Image.FLIP_LEFT_RIGHT).transpose(Image.ROTATE_270)
+            elif orientation == 8:
+                im = im.transpose(Image.ROTATE_90)
+
+        if self.__image_rotate == 90:
             im = im.transpose(Image.ROTATE_90)
+        elif self.__image_rotate == 180:
+            im = im.transpose(Image.ROTATE_180)
+        elif self.__image_rotate == 270:
+            im = im.transpose(Image.ROTATE_270)
+
         return im
 
     def __get_mat_image_control_values(self, mat_images_value):
@@ -303,15 +314,13 @@ class ViewerDisplay:
                 im = get_image_meta.GetImageMeta.get_image_object(pics[0].fname)
                 if im is None:
                     return None
-                if pics[0].orientation != 1:
-                    im = self.__orientate_image(im, pics[0])
+                im = self.__orientate_image(im, pics[0])
 
             if pics[1]:
                 im2 = get_image_meta.GetImageMeta.get_image_object(pics[1].fname)
                 if im2 is None:
                     return None
-                if pics[1].orientation != 1:
-                    im2 = self.__orientate_image(im2, pics[1])
+                im2 = self.__orientate_image(im2, pics[1])
 
             screen_aspect, image_aspect, diff_aspect = self.__get_aspect_diff(size, im.size)
 


### PR DESCRIPTION
Per issue #401 I had a thought for what would be a simpler solution that is not dependent on the specific OS version or hardware type. I simply added the option to rotate the images on load by 90, 180, or 270 degrees.

I entirely realize that this is not a solution for everyone as it's a bit simplistic and doesn't effect and other text or graphic overlays. I tried to see if there was a good/easy way to rotate the entire view space after compositing but couldn't figure out anything obvious. I'm certainly option to suggestions for better ways to do this. If so, let me know and I'll do what I can. But I figured this could still be helpful in some cases for some people.

For myself, specifically, it solves my problems because I didn't want to show anything other than the images anyways. 