### PR TITLE
feat/weighted sampling

### DIFF
--- a/src/picframe/config/configuration_example.yaml
+++ b/src/picframe/config/configuration_example.yaml
@@ -61,6 +61,8 @@ model:
   no_files_img: "~/picframe_data/data/no_pictures.jpg" # default="PictureFrame2020img.jpg", image to show if none selected
   subdirectory: ""                        # default="", subdir of pic_dir - can be changed by MQTT"
   recent_n: 7                             # default=7 (days), when shuffling file change date more recent than this number of days play before the rest
+  age_weighted_sampling: False            # default=False, when True uses age-weighted sampling instead of recent_n binary sorting
+  recency_bias: 2.0                       # default=2.0, controls how strongly recent photos are favored (higher = more bias toward recent)
   reshuffle_num: 1                        # default=1, times through before reshuffling
   time_delay: 200.0                       # default=200.0, time between consecutive slide starts - can be changed by MQTT
   fade_time: 10.0                         # default=10.0, change time during which slides overlap - can be changed by MQTT"

--- a/src/picframe/config/configuration_example.yaml
+++ b/src/picframe/config/configuration_example.yaml
@@ -63,6 +63,7 @@ model:
   recent_n: 7                             # default=7 (days), when shuffling file change date more recent than this number of days play before the rest
   age_weighted_sampling: False            # default=False, when True uses age-weighted sampling instead of recent_n binary sorting
   recency_bias: 2.0                       # default=2.0, controls how strongly recent photos are favored (higher = more bias toward recent)
+  sample_limit: null                      # default=null, limits number of photos sampled for display (useful for large collections to increase variety)
   reshuffle_num: 1                        # default=1, times through before reshuffling
   time_delay: 200.0                       # default=200.0, time between consecutive slide starts - can be changed by MQTT
   fade_time: 10.0                         # default=10.0, change time during which slides overlap - can be changed by MQTT"

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -528,10 +528,10 @@ class Model:
         2. Applies exponential decay weighting (newer = much higher weight)
         3. Randomly selects photos based on these weights
         
-        The 'recency_bias' setting controls how strongly it favors newer photos:
-        - Value of 1: Creates balanced selection between old and new photos
-        - Value of 2: Provides moderate preference for recent photos (default)
-        - Value of 3: Creates strong preference for recent photos
+        The 'recency_bias' setting controls how strongly it favours newer photos:
+        - A value of 1.0: Creates balanced selection between old and new photos
+        - A value of 2.0: Provides moderate preference for recent photos (default)
+        - A value of 3.0: Creates strong preference for recent photos
         """
         # Get all files with their timestamps
         cursor = self.__image_cache._ImageCache__db.cursor()

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -516,8 +516,22 @@ class Model:
 
     def __get_weighted_sample(self, where_clause):
         """
-        Get photos using age-weighted sampling instead of recent_n binary sorting.
-        Photos are weighted by age percentile with exponential decay.
+        Selects photos using age-based weighting instead of simple recent/old grouping.
+        
+        This creates a more natural photo viewing experience by:
+        - Giving newer photos a higher probability of being selected
+        - Still showing older photos (preventing them from being forgotten)
+        - Using smooth probability curves instead of hard cutoffs
+        
+        How it works:
+        1. Calculates each photo's "age rank" from newest (0%) to oldest (100%)
+        2. Applies exponential decay weighting (newer = much higher weight)
+        3. Randomly selects photos based on these weights
+        
+        The 'recency_bias' setting controls how strongly it favors newer photos:
+        - Value of 1: Creates balanced selection between old and new photos
+        - Value of 2: Provides moderate preference for recent photos (default)
+        - Value of 3: Creates strong preference for recent photos
         """
         # Get all files with their timestamps
         cursor = self.__image_cache._ImageCache__db.cursor()

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -3,6 +3,8 @@ import os
 import time
 import logging
 import locale
+import math
+import random
 from picframe import geo_reverse, image_cache
 
 DEFAULT_CONFIGFILE = "~/picframe_data/config/configuration.yaml"
@@ -63,6 +65,8 @@ DEFAULT_CONFIG = {
         'follow_links': False,
         'subdirectory': '',
         'recent_n': 3,
+        'age_weighted_sampling': False,
+        'recency_bias': 2.0,
         'reshuffle_num': 1,
         'time_delay': 200.0,
         'fade_time': 10.0,
@@ -480,28 +484,120 @@ class Model:
         else:
             where_clause = "1"
 
-        sort_list = []
-        recent_n = self.get_model_config()["recent_n"]
-        if recent_n > 0:
-            sort_list.append("last_modified < {:.0f}".format(time.time() - 3600 * 24 * recent_n))
-
-        if self.shuffle:
-            sort_list.append("RANDOM()")
+        model_config = self.get_model_config()
+        age_weighted_sampling = model_config.get("age_weighted_sampling", False)
+        
+        if age_weighted_sampling:
+            # Use age-weighted sampling instead of recent_n binary sorting
+            self.__file_list = self.__get_weighted_sample(where_clause)
         else:
-            if self.__col_names is None:
-                self.__col_names = self.__image_cache.get_column_names()  # do this once
-            for col in self.__sort_cols.split(","):
-                colsplit = col.split()
-                if colsplit[0] in self.__col_names and (len(colsplit) == 1 or colsplit[1].upper() in ("ASC", "DESC")):
-                    sort_list.append(col)
-            sort_list.append("fname ASC")  # always finally sort on this in case nothing else to sort on or sort_cols is "" # noqa: E501
-        sort_clause = ",".join(sort_list)
+            # Original logic with recent_n
+            sort_list = []
+            recent_n = model_config["recent_n"]
+            if recent_n > 0:
+                sort_list.append("last_modified < {:.0f}".format(time.time() - 3600 * 24 * recent_n))
 
-        self.__file_list = self.__image_cache.query_cache(where_clause, sort_clause)
+            if self.shuffle:
+                sort_list.append("RANDOM()")
+            else:
+                if self.__col_names is None:
+                    self.__col_names = self.__image_cache.get_column_names()  # do this once
+                for col in self.__sort_cols.split(","):
+                    colsplit = col.split()
+                    if colsplit[0] in self.__col_names and (len(colsplit) == 1 or colsplit[1].upper() in ("ASC", "DESC")):
+                        sort_list.append(col)
+                sort_list.append("fname ASC")  # always finally sort on this in case nothing else to sort on or sort_cols is "" # noqa: E501
+            sort_clause = ",".join(sort_list)
+            self.__file_list = self.__image_cache.query_cache(where_clause, sort_clause)
         self.__number_of_files = len(self.__file_list)
         self.__file_index = 0
         self.__num_run_through = 0
         self.__reload_files = False
+
+    def __get_weighted_sample(self, where_clause):
+        """
+        Get photos using age-weighted sampling instead of recent_n binary sorting.
+        Photos are weighted by age percentile with exponential decay.
+        """
+        # Get all files with their timestamps
+        cursor = self.__image_cache._ImageCache__db.cursor()
+        cursor.row_factory = None
+        
+        if not self.__image_cache._ImageCache__portrait_pairs:
+            sql = """SELECT file_id, last_modified FROM all_data WHERE {0}""".format(where_clause)
+            rows = cursor.execute(sql).fetchall()
+            file_data = [(row[0], row[1]) for row in rows]
+        else:
+            # Handle portrait pairs - simplified for now, using same logic as original
+            sql = """SELECT
+                        CASE
+                            WHEN is_portrait = 0 THEN file_id
+                            ELSE -1
+                        END as file_id,
+                        last_modified
+                        FROM all_data WHERE {0}""".format(where_clause)
+            rows = cursor.execute(sql).fetchall()
+            file_data = [(row[0], row[1]) for row in rows if row[0] != -1]
+        
+        if len(file_data) == 0:
+            return []
+        
+        # Calculate age percentiles and weights
+        timestamps = [data[1] for data in file_data]
+        min_time = min(timestamps)
+        max_time = max(timestamps)
+        time_range = max_time - min_time
+        
+        if time_range == 0:
+            # All photos have same timestamp, treat equally
+            weights = [1.0] * len(file_data)
+        else:
+            recency_bias = self.get_model_config().get("recency_bias", 2.0)
+            weights = []
+            for _, timestamp in file_data:
+                # Calculate age percentile (0.0 = newest, 1.0 = oldest)
+                age_percentile = (max_time - timestamp) / time_range
+                # Calculate weight using exponential decay
+                weight = math.exp(-age_percentile * recency_bias)
+                weights.append(weight)
+        
+        # Weighted sampling without replacement
+        sampled_files = []
+        remaining_files = list(range(len(file_data)))
+        remaining_weights = weights[:]
+        
+        # Sample all files with their computed probabilities
+        while remaining_files:
+            # Normalize weights to probabilities
+            total_weight = sum(remaining_weights)
+            if total_weight == 0:
+                break
+                
+            probabilities = [w / total_weight for w in remaining_weights]
+            
+            # Sample one file
+            rand_val = random.random()
+            cumulative_prob = 0
+            selected_idx = 0
+            
+            for i, prob in enumerate(probabilities):
+                cumulative_prob += prob
+                if rand_val <= cumulative_prob:
+                    selected_idx = i
+                    break
+            
+            # Add selected file to result
+            file_idx = remaining_files[selected_idx]
+            if not self.__image_cache._ImageCache__portrait_pairs:
+                sampled_files.append((file_data[file_idx][0],))
+            else:
+                sampled_files.append((file_data[file_idx][0],))  # Simplified for now
+            
+            # Remove from remaining
+            remaining_files.pop(selected_idx)
+            remaining_weights.pop(selected_idx)
+        
+        return sampled_files
 
     def __generate_random_string(self, length):
         random_bytes = os.urandom(length // 2)

--- a/src/picframe/model.py
+++ b/src/picframe/model.py
@@ -522,16 +522,23 @@ class Model:
         - Giving newer photos a higher probability of being selected
         - Still showing older photos (preventing them from being forgotten)
         - Using smooth probability curves instead of hard cutoffs
+        - Optionally limiting the sample size to force more frequent re-shuffling
         
         How it works:
         1. Calculates each photo's "age rank" from newest (0%) to oldest (100%)
         2. Applies exponential decay weighting (newer = much higher weight)
         3. Randomly selects photos based on these weights
+        4. Limits selection to sample_limit photos if specified
         
-        The 'recency_bias' setting controls how strongly it favours newer photos:
-        - A value of 1.0: Creates balanced selection between old and new photos
-        - A value of 2.0: Provides moderate preference for recent photos (default)
-        - A value of 3.0: Creates strong preference for recent photos
+        Configuration options:
+        - 'recency_bias': Controls how strongly it favours newer photos:
+          * A value of 1.0: Creates balanced selection between old and new photos
+          * A value of 2.0: Provides moderate preference for recent photos (default)
+          * A value of 3.0: Creates strong preference for recent photos
+        - 'sample_limit': Optional limit on number of photos to sample:
+          * If None (default): Samples all available photos
+          * If set to N: Samples only N photos, causing more frequent re-shuffling
+          * Useful for devices with large photo collections to increase variety
         """
         # Get all files with their timestamps
         cursor = self.__image_cache._ImageCache__db.cursor()
@@ -575,13 +582,17 @@ class Model:
                 weight = math.exp(-age_percentile * recency_bias)
                 weights.append(weight)
         
+        # Check for optional sample limit
+        sample_limit = self.get_model_config().get("sample_limit", None)
+        max_samples = len(file_data) if sample_limit is None else min(sample_limit, len(file_data))
+        
         # Weighted sampling without replacement
         sampled_files = []
         remaining_files = list(range(len(file_data)))
         remaining_weights = weights[:]
         
-        # Sample all files with their computed probabilities
-        while remaining_files:
+        # Sample files with their computed probabilities (up to sample_limit)
+        while remaining_files and len(sampled_files) < max_samples:
             # Normalize weights to probabilities
             total_weight = sum(remaining_weights)
             if total_weight == 0:

--- a/test_weighted_sampling.py
+++ b/test_weighted_sampling.py
@@ -90,7 +90,30 @@ def test_weighted_sampling():
         
         print(f"Selection probability - Newest: {newest_prob:.1%}, Oldest: {oldest_prob:.1%}")
         
-        print("\n Tests passed")
+        # Test sample limit functionality
+        print("\nTesting sample_limit feature...")
+        test_sample_limits = [10, 50, 200]  # Including one larger than available
+        
+        for sample_limit in test_sample_limits:
+            max_samples = min(sample_limit, len(test_photos))
+            print(f"Sample limit {sample_limit}: Will sample {max_samples} photos out of {len(test_photos)}")
+            
+            # Simulate the sampling logic with limit
+            remaining_files = list(range(len(test_photos)))
+            remaining_weights = weights[:]
+            sampled_count = 0
+            
+            # Sample with limit
+            while remaining_files and sampled_count < max_samples:
+                # Simple sampling for test (just pick first)
+                remaining_files.pop(0)
+                remaining_weights.pop(0)
+                sampled_count += 1
+            
+            assert sampled_count == max_samples, f"Should sample exactly {max_samples} photos"
+        
+        print("Sample limit tests passed!")
+        print("\nAll tests passed")
         
     except Exception as e:
         print(f"Test failed with error: {e}")

--- a/test_weighted_sampling.py
+++ b/test_weighted_sampling.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import tempfile
+import sqlite3
+import time
+import math
+
+# Add the src directory to path so we can import picframe
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+def create_test_database():
+    # Create a temporary database with test photo data
+    db_fd, db_path = tempfile.mkstemp(suffix='.db3')
+    os.close(db_fd)
+    
+    conn = sqlite3.connect(db_path)
+    conn.execute('''CREATE TABLE all_data (
+        file_id INTEGER PRIMARY KEY,
+        fname TEXT,
+        last_modified INTEGER,
+        is_portrait INTEGER DEFAULT 0
+    )''')
+    
+    # List of test photos
+    current_time = int(time.time())
+    test_photos = []
+    
+    # Create 100 photos spanning 2 years
+    for i in range(100):
+        # Age ranges from 0 to 730 days (2 years)
+        days_old = i * 7  # Weekly intervals
+        timestamp = current_time - (days_old * 24 * 3600)
+        fname = f'/test/photos/photo_{i:03d}.jpg'
+        
+        conn.execute('INSERT INTO all_data (file_id, fname, last_modified, is_portrait) VALUES (?, ?, ?, 0)',
+                    (i + 1, fname, timestamp))
+        test_photos.append((i + 1, timestamp))
+    
+    conn.commit()
+    conn.close()
+    
+    return db_path, test_photos
+
+def test_weighted_sampling():
+    # Test the weighted sampling algorithm
+    print("Testing age-weighted sampling...")
+    
+    # Create test database
+    db_path, test_photos = create_test_database()
+    
+    try:
+        # Test the weighted sampling logic directly without full imports
+        # This avoids dependency issues while testing functionality
+        timestamps = [photo[1] for photo in test_photos]
+        min_time = min(timestamps)
+        max_time = max(timestamps)
+        time_range = max_time - min_time
+        
+        print(f"Created test database with {len(test_photos)} photos spanning {time_range / (24*3600):.1f} days")
+        
+        # Test weight calculation
+        recency_bias = 2.0
+        weights = []
+        
+        for _, timestamp in test_photos:
+            # Calculate age percentile (0.0 = newest, 1.0 = oldest)
+            age_percentile = (max_time - timestamp) / time_range
+            # Calculate weight using exponential decay
+            weight = math.exp(-age_percentile * recency_bias)
+            weights.append(weight)
+        
+        # Verify weight distribution
+        newest_weight = weights[0]  # First photo is newest
+        oldest_weight = weights[-1]  # Last photo is oldest
+        middle_idx = len(weights) // 2
+        middle_weight = weights[middle_idx]
+        
+        print(f"Weight distribution - Newest: {newest_weight:.3f}, Middle: {middle_weight:.3f}, Oldest: {oldest_weight:.3f}")
+        print(f"Recent photos are {newest_weight/oldest_weight:.1f}x more likely than oldest")
+        
+        # Verify weights decrease with age
+        assert weights[0] > weights[25] > weights[50] > weights[99], "Weights should decrease with age"
+        
+        # Test sampling probability calculation
+        total_weight = sum(weights)
+        newest_prob = newest_weight / total_weight
+        oldest_prob = oldest_weight / total_weight
+        
+        print(f"Selection probability - Newest: {newest_prob:.1%}, Oldest: {oldest_prob:.1%}")
+        
+        print("\n Tests passed")
+        
+    except Exception as e:
+        print(f"Test failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+    finally:
+        # Clean up
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+if __name__ == "__main__":
+    test_weighted_sampling()


### PR DESCRIPTION
Added weighted sampling to increase the frequency of newer photos. Added an optional `sample_limit` parameter to limit the number of photos selected every time to increase shuffle frequency.

## Summary by Sourcery

Implement an age-based weighted sampling mechanism for photo selection with configurable bias and sample limits, integrate it into the existing file loader, and update configuration and tests accordingly

New Features:
- Add optional age-weighted sampling of photos to favor newer images using exponential decay weighting
- Introduce 'recency_bias' and 'sample_limit' configuration parameters to control the strength of recency preference and limit the number of photos sampled
- Integrate weighted sampling into the file selection logic while preserving the original sorting behavior when disabled

Documentation:
- Update configuration example to include 'age_weighted_sampling', 'recency_bias', and 'sample_limit' settings

Tests:
- Add unit tests for weighted sampling algorithm, weight distribution, and sample limit behavior