### PR TITLE
make refreshPage() work correctly for boolean values (issue #562)

### DIFF
--- a/src/picframe/html/pf_functions.js
+++ b/src/picframe/html/pf_functions.js
@@ -54,9 +54,9 @@ function refreshPage() {
             }
         } else if (element.type === "bool") {
             if (value == true || value === "true" || value === "True" || value === "ON") {
-                value = "true";
+                value = true;
             } else {
-                value = "false";
+                value = false;
             }
         }
         docElement.value = value; //TODO have some fields not changed by ids.val?


### PR DESCRIPTION
Within refreshPage() incoming value is analyzed for boolean elements to be either true or false. The value was then set to "true" or "false" strings instead of boolean values. This led to incorrect display of boolean values (e.g. 'Pause'), which have been assumed to be true, although value was string "false".
This will solve issue #562

## Summary by Sourcery

Bug Fixes:
- Set refreshPage to use true/false booleans instead of "true"/"false" strings to fix incorrect boolean display